### PR TITLE
Port to 1.16.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,6 @@ buildscript {
     }
 }
 
-
-
-plugins {
-    id "com.wynprice.cursemaven" version "2.1.1"
-}
-
 //repositories {
 //    flatDir {
 //        dirs 'deps'
@@ -27,7 +21,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.16.1-2.1.0'
+version = '1.16.4-2.1.0'
 group = 'realmayus.youmatter' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'youmatter'
 
@@ -39,7 +33,7 @@ minecraft {
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20200723-1.16.1'
+    mappings channel: 'snapshot', version: '20201028-1.16.3'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -57,7 +51,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                examplemod {
+                youmatter {
                     source sourceSets.main
                 }
             }
@@ -73,7 +67,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                examplemod {
+                youmatter {
                     source sourceSets.main
                 }
             }
@@ -91,7 +85,7 @@ minecraft {
             args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
 
             mods {
-                examplemod {
+                youmatter {
                     source sourceSets.main
                 }
             }
@@ -103,7 +97,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.16.1-32.0.108'
+    minecraft 'net.minecraftforge:forge:1.16.4-35.1.7'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/java/realmayus/youmatter/creator/CreatorScreen.java
+++ b/src/main/java/realmayus/youmatter/creator/CreatorScreen.java
@@ -96,8 +96,7 @@ public class CreatorScreen extends ContainerScreen<CreatorContainer> {
         this.renderBackground(matrixStack);
         super.render(matrixStack, mouseX, mouseY, partialTicks);
         //Render any tooltips
-        //Mappings are not complete, I took a guess that this is actually renderHoveredTooltip
-        this.func_230459_a_(matrixStack, mouseX, mouseY);
+        this.renderHoveredTooltip(matrixStack, mouseX, mouseY);
 
         int xAxis = (mouseX - (width - xSize) / 2);
         int yAxis = (mouseY - (height - ySize) / 2);
@@ -118,7 +117,7 @@ public class CreatorScreen extends ContainerScreen<CreatorContainer> {
 
 
     private void drawTooltip(MatrixStack matrixStack, int x, int y, List<ITextComponent> tooltips) {
-        renderTooltip(matrixStack, tooltips, x, y);
+        func_243308_b(matrixStack, tooltips, x, y);
     }
 
 

--- a/src/main/java/realmayus/youmatter/encoder/EncoderBlock.java
+++ b/src/main/java/realmayus/youmatter/encoder/EncoderBlock.java
@@ -2,6 +2,8 @@ package realmayus.youmatter.encoder;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.ChestBlock;
+import net.minecraft.block.ShulkerBoxBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.item.ItemEntity;
@@ -64,16 +66,13 @@ public class EncoderBlock extends Block {
 
         return te instanceof EncoderTile ? (INamedContainerProvider)te : null;
     }
-
+    
     @Override
-    public void onPlayerDestroy(IWorld worldIn, BlockPos pos, BlockState state) {
+    public void onBlockHarvested(World worldIn, BlockPos pos, BlockState state, PlayerEntity player) {
         TileEntity te = worldIn.getTileEntity(pos);
-        if (te != null) {
-            if(te instanceof EncoderTile){
-                te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(h -> IntStream.range(0, h.getSlots()).forEach(i -> worldIn.addEntity(new ItemEntity(worldIn.getWorld(), pos.getX(), pos.getY(), pos.getZ(), h.getStackInSlot(i)))));
-
-            }
+        if(te instanceof EncoderTile){
+            te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(h -> IntStream.range(0, h.getSlots()).forEach(i -> worldIn.addEntity(new ItemEntity(worldIn, pos.getX(), pos.getY(), pos.getZ(), h.getStackInSlot(i)))));
         }
-        super.onPlayerDestroy(worldIn, pos, state);
+        super.onBlockHarvested(worldIn, pos, state, player);
     }
 }

--- a/src/main/java/realmayus/youmatter/encoder/EncoderScreen.java
+++ b/src/main/java/realmayus/youmatter/encoder/EncoderScreen.java
@@ -38,8 +38,7 @@ public class EncoderScreen extends ContainerScreen<EncoderContainer> {
         this.renderBackground(matrixStack);
         super.render(matrixStack, mouseX, mouseY, partialTicks);
 
-        //Mappings are not complete, I took a guess that this is actually renderHoveredTooltip
-        this.func_230459_a_(matrixStack, mouseX, mouseY);
+        this.renderHoveredTooltip(matrixStack, mouseX, mouseY);
 
         int xAxis = (mouseX - (width - WIDTH) / 2);
         int yAxis = (mouseY - (height - HEIGHT) / 2);
@@ -135,6 +134,6 @@ public class EncoderScreen extends ContainerScreen<EncoderContainer> {
     }
 
     private void drawTooltip(MatrixStack matrixStack, int x, int y, List<ITextComponent> tooltips) {
-        renderTooltip(matrixStack, tooltips, x, y);
+        func_243308_b(matrixStack, tooltips, x, y);
     }
 }

--- a/src/main/java/realmayus/youmatter/replicator/ReplicatorBlock.java
+++ b/src/main/java/realmayus/youmatter/replicator/ReplicatorBlock.java
@@ -102,15 +102,12 @@ public class ReplicatorBlock extends Block {
     }
 
     @Override
-    public void onPlayerDestroy(IWorld worldIn, BlockPos pos, BlockState state) {
+    public void onBlockHarvested(World worldIn, BlockPos pos, BlockState state, PlayerEntity player) {
         TileEntity te = worldIn.getTileEntity(pos);
-        if (te != null) {
-            if(te instanceof ReplicatorTile){
-                te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(h -> IntStream.range(0, h.getSlots()).forEach(i -> worldIn.addEntity(new ItemEntity(worldIn.getWorld(), pos.getX(), pos.getY(), pos.getZ(), h.getStackInSlot(i)))));
-
-            }
+        if(te instanceof ReplicatorTile){
+            te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(h -> IntStream.range(0, h.getSlots()).forEach(i -> worldIn.addEntity(new ItemEntity(worldIn, pos.getX(), pos.getY(), pos.getZ(), h.getStackInSlot(i)))));
         }
-        super.onPlayerDestroy(worldIn, pos, state);
+        super.onBlockHarvested(worldIn, pos, state, player);
     }
 
 }

--- a/src/main/java/realmayus/youmatter/replicator/ReplicatorScreen.java
+++ b/src/main/java/realmayus/youmatter/replicator/ReplicatorScreen.java
@@ -120,8 +120,7 @@ public class ReplicatorScreen extends ContainerScreen<ReplicatorContainer> {
 
 
         //Render any tooltips
-        //Mappings are not complete, I took a guess that this is actually renderHoveredTooltip
-        func_230459_a_(matrixStack, mouseX, mouseY);
+        renderHoveredTooltip(matrixStack, mouseX, mouseY);
 
         int xAxis = (mouseX - (width - xSize) / 2);
         int yAxis = (mouseY - (height - ySize) / 2);
@@ -144,7 +143,7 @@ public class ReplicatorScreen extends ContainerScreen<ReplicatorContainer> {
     }
 
     private void drawTooltip(MatrixStack matrixStack, int x, int y, List<ITextComponent> tooltips) {
-        renderTooltip(matrixStack, tooltips, x, y);
+        func_243308_b(matrixStack, tooltips, x, y);
     }
 
     @Override

--- a/src/main/java/realmayus/youmatter/scanner/ScannerBlock.java
+++ b/src/main/java/realmayus/youmatter/scanner/ScannerBlock.java
@@ -70,14 +70,11 @@ public class ScannerBlock extends Block {
     }
 
     @Override
-    public void onPlayerDestroy(IWorld worldIn, BlockPos pos, BlockState state) {
+    public void onBlockHarvested(World worldIn, BlockPos pos, BlockState state, PlayerEntity player) {
         TileEntity te = worldIn.getTileEntity(pos);
-        if (te != null) {
-            if(te instanceof ScannerTile){
-                te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(h -> IntStream.range(0, h.getSlots()).forEach(i -> worldIn.addEntity(new ItemEntity(worldIn.getWorld(), pos.getX(), pos.getY(), pos.getZ(), h.getStackInSlot(i)))));
-
-            }
+        if(te instanceof ScannerTile){
+            te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(h -> IntStream.range(0, h.getSlots()).forEach(i -> worldIn.addEntity(new ItemEntity(worldIn, pos.getX(), pos.getY(), pos.getZ(), h.getStackInSlot(i)))));
         }
-        super.onPlayerDestroy(worldIn, pos, state);
+        super.onBlockHarvested(worldIn, pos, state, player);
     }
 }

--- a/src/main/java/realmayus/youmatter/scanner/ScannerScreen.java
+++ b/src/main/java/realmayus/youmatter/scanner/ScannerScreen.java
@@ -33,8 +33,7 @@ public class ScannerScreen extends ContainerScreen<ScannerContainer> {
     public void render(MatrixStack matrixStack, int mouseX, int mouseY, float partialTicks) {
         this.renderBackground(matrixStack);
         super.render(matrixStack, mouseX, mouseY, partialTicks);
-        //Mappings are not complete, I took a guess that this is actually renderHoveredTooltip
-        this.func_230459_a_(matrixStack, mouseX, mouseY);
+        this.renderHoveredTooltip(matrixStack, mouseX, mouseY);
 
         int xAxis = (mouseX - (width - WIDTH) / 2);
         int yAxis = (mouseY - (height - HEIGHT) / 2);
@@ -106,6 +105,6 @@ public class ScannerScreen extends ContainerScreen<ScannerContainer> {
     }
 
     private void drawTooltip(MatrixStack matrixStack, int x, int y, List<ITextComponent> tooltips) {
-        renderTooltip(matrixStack, tooltips, x, y);
+        func_243308_b(matrixStack, tooltips, x, y);
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,11 +1,12 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml"
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[31,)"
+loaderVersion="[35,)"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/realmayus/youmatter/issues"
 # If the mods defined in this file should show as seperate resource packs
 showAsResourcePack=false
+license="MIT License"
 
 [[mods]]
   modId="youmatter"
@@ -21,13 +22,13 @@ showAsResourcePack=false
   [[dependencies.youmatter]]
     modId="forge"
     mandatory=true
-    versionRange="[31,)"
+    versionRange="[35,)"
     ordering="NONE"
     side="BOTH"
 
   [[dependencies.youmatter]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.1]"
+    versionRange="[1.16.4]"
     ordering="NONE"
     side="BOTH"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,6 @@
 {
     "pack": {
         "description": "youmatter resources",
-        "pack_format": 3,
-        "_comment": "A pack_format of 3 should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang). A pack_format of 2 will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang)."
+        "pack_format": 6
     }
 }


### PR DESCRIPTION
Note: I am pull requesting this onto branch 1.16.1, because there is none for 1.16.4, however if you want this port to be on a separate branch, you can create a new branch, then change the target branch of this pull request.

I changed the `onPlayerDestroy` overrides to `onBlockHarvested` because the world provided by the former is not of the proper type for the `ItemEntity` constructor, and the shulker box uses that as well to make it drop like it does. At the same time, I removed the null check before the instanceof check, because `instanceof` implicitly checks for `null`. You don't need an extra null check infront of an instanceof.
I also fixed launch configs not generating properly.

Also a couple things that I noticed, but have not included in this PR:
- For the screens, save the text components as static final values if possible, to prevent a new object from being created every tick.
- Uneducated assumption based on loose knowledge: To create a list, using `Arrays#asList` is better than constructing and collecting a stream (especially when done every tick).
- Your `mods.toml` still has the description (and I think credits as well) from the example mod. Consider changing this.